### PR TITLE
Deprecate SearchPassword for FindPassword

### DIFF
--- a/src/TeamPasswordManagerClient/Properties/AssemblyInfo.cs
+++ b/src/TeamPasswordManagerClient/Properties/AssemblyInfo.cs
@@ -29,6 +29,6 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
-[assembly: AssemblyInformationalVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.2.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyInformationalVersion("1.2.0.0")]

--- a/src/TeamPasswordManagerClient/TpmPasswordClient.cs
+++ b/src/TeamPasswordManagerClient/TpmPasswordClient.cs
@@ -36,6 +36,13 @@ namespace TeamPasswordManagerClient
         /// <param name="id"></param>
         /// <returns></returns>
         Task<PasswordDetails> GetPassword(int id);
+        
+        /// <summary>
+        /// Search for a password entry by name.
+        /// </summary>
+        /// <param name="passwordName"></param>
+        /// <returns></returns>
+        Task<IEnumerable<PasswordEntry>> FindPassword(string passwordName);
 
         /// <summary>
         /// Search for a password entry by name.
@@ -43,6 +50,7 @@ namespace TeamPasswordManagerClient
         /// <param name="projectName">NOTE: Spaces in a project name will fail to return any results</param>
         /// <param name="passwordName"></param>
         /// <returns></returns>
+        [Obsolete("This method is obsolete. Call FindPassword instead.", true)]
         Task<PasswordEntry> SearchPassword(string projectName, string passwordName);
 
         /// <summary>
@@ -117,6 +125,14 @@ namespace TeamPasswordManagerClient
             return Json.ToObject<PasswordDetails>(response);
         }
 
+        public async Task<IEnumerable<PasswordEntry>> FindPassword(string passwordName)
+        {
+            var urlencodedPassword = HttpUtility.UrlEncode($"\"{passwordName}\"");
+            var response = await http.Get($"api/v4/passwords/search/name:{urlencodedPassword}.json");
+            return Json.ToObject<List<PasswordEntry>>(response);
+        }
+
+        [Obsolete("This method is obsolete. Call FindPassword instead.", true)]
         public async Task<PasswordEntry> SearchPassword(string projectName, string passwordName)
         {
             var urlencodedProject = HttpUtility.UrlEncode($"[{projectName}]");


### PR DESCRIPTION
In all my testing I couldn't actually get SearchPassword to work. Searching in tpm with the same syntax yields no results e.g: `name:[15below-qa607.ams01.viawesthosted.net] in:[Upgrades - Lufthansa]` I believe this is due to the `in` operator not supporting 'exact match' (square brackets).
Since i cannot be 100% sure that it doesn't work in all scenarios, I propose obsoleting the old method and instead introducing a more usable search method which is not restricted by exact matching.